### PR TITLE
Snake can wrap around the grid

### DIFF
--- a/src/models/Snake/Snake.spec.ts
+++ b/src/models/Snake/Snake.spec.ts
@@ -200,10 +200,6 @@ describe('Snake', () => {
   });
 
   describe('Snake.grow()', () => {
-    head = [20, 20];
-    gridSize = 41;
-    direction = Direction.UP;
-
     it('adds another segment to itself on the next step (only)', () => {
       testSnake = new Snake(head, gridSize, direction);
       expect(testSnake.length).toBe(3);
@@ -216,6 +212,49 @@ describe('Snake', () => {
 
       testSnake.step();
       expect(testSnake.length).toBe(4);
+    });
+  });
+
+  describe('wrapping around the grid', () => {
+    [
+      {
+        direction: Direction.DOWN,
+        caseHead: [10, 10],
+        caseGridSize: 12,
+        wrappedCoordinates: [
+          [0, 10],
+          [11, 10],
+          [10, 10],
+        ],
+      },
+      {
+        direction: Direction.UP,
+        caseHead: [0, 2],
+        caseGridSize: 5,
+        wrappedCoordinates: [
+          [3, 2],
+          [4, 2],
+          [0, 2],
+        ],
+      },
+      {
+        direction: Direction.LEFT,
+        caseHead: [84, 0],
+        caseGridSize: 200,
+        wrappedCoordinates: [
+          [84, 198],
+          [84, 199],
+          [84, 0],
+        ],
+      },
+    ].forEach(({direction, caseHead, caseGridSize, wrappedCoordinates}) => {
+      it('wraps its coordinates around the boundaries of its gridSize', () => {
+        testSnake = new Snake(caseHead as Coordinate, caseGridSize, direction);
+        testSnake.step();
+        testSnake.step();
+
+        expect(testSnake.body).toEqual(wrappedCoordinates);
+      });
     });
   });
 });

--- a/src/models/Snake/Snake.ts
+++ b/src/models/Snake/Snake.ts
@@ -1,5 +1,6 @@
 import {SnakeErrors} from '../../common/errors';
 import {Coordinate, Direction} from '../../common/types';
+import {mod} from '../../common/utils';
 
 import {getInitialSegments} from './utils';
 
@@ -62,13 +63,13 @@ export class Snake {
 
     switch (this._direction) {
       case Direction.UP:
-        return [row - 1, col];
+        return [mod(row - 1, this._gridSize), col];
       case Direction.DOWN:
-        return [row + 1, col];
+        return [mod(row + 1, this._gridSize), col];
       case Direction.LEFT:
-        return [row, col - 1];
+        return [row, mod(col - 1, this._gridSize)];
       case Direction.RIGHT:
-        return [row, col + 1];
+        return [row, mod(col + 1, this._gridSize)];
       default:
     }
   }


### PR DESCRIPTION
# What does this PR do?

Allows the Snake to wrap its coordinates around the given `gridSize`